### PR TITLE
Use -shared as default when compiling NIF:s

### DIFF
--- a/erl.mk
+++ b/erl.mk
@@ -357,12 +357,12 @@ c_src.mk:
 	printf 'CFLAGS ?= -std=c99 $$(CWARNINGS) $$(CEXTRA_FLAGS)\n' >> $@; \
 	printf 'CFLAGS += -MMD -MP -MF .$$<.d -I$$(ERL_TOP)/usr/include\n' >>$@;\
 	printf '\n' >> $@; \
-	printf 'ifeq ($$(OS), Linux)\n' >> $@; \
-	printf '  LDFLAGS_NIF = -shared\n' >> $@; \
-	printf '  CFLAGS += -fPIC\n' >> $@; \
-	printf 'else ifeq ($$(OS), Darwin)\n' >> $@; \
+	printf 'ifeq ($$(OS), Darwin)\n' >> $@; \
 	printf '  LDFLAGS_NIF = -bundle -undefined dynamic_lookup\n' >> $@; \
 	printf '  CFLAGS += -fPIC -fno-common\n' >> $@; \
+	printf 'else\n' >> $@; \
+	printf '  LDFLAGS_NIF = -shared\n' >> $@; \
+	printf '  CFLAGS += -fPIC\n' >> $@; \
 	printf 'endif\n' >> $@; \
 	printf '\n' >> $@; \
 	printf 'ifneq ($$(MAKECMDGOALS),clean)\n' >> $@; \

--- a/test/lux/nif/Makefile
+++ b/test/lux/nif/Makefile
@@ -1,0 +1,12 @@
+
+ERLMKTOP ?= $(shell cd ../../../; pwd)
+export ERLMKTOP
+
+TESTDIR ?= $(shell cd ..; pwd)
+export TESTDIR
+
+include erl.mk
+
+erl.mk:
+	cp $(ERLMKTOP)/erl.mk .
+

--- a/test/lux/nif/c_src/Makefile
+++ b/test/lux/nif/c_src/Makefile
@@ -1,0 +1,15 @@
+NIF = ../priv/n.so
+
+all: $(NIF)
+
+include c_src.mk
+
+c_src.mk:
+	$(MAKE) -f ../erl.mk $@
+
+SOURCES := $(wildcard *.c)
+OBJS := $(SOURCES:%.c=./%.o)
+
+$(NIF): $(OBJS)
+	@mkdir -p $(dir $@)
+	$(CC) $(LDFLAGS_NIF) -o $@ $^ $(LIBS)

--- a/test/lux/nif/c_src/n.c
+++ b/test/lux/nif/c_src/n.c
@@ -1,0 +1,12 @@
+#include "erl_nif.h"
+
+static ERL_NIF_TERM hello_world(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    return enif_make_string(env, "Hello world", ERL_NIF_UTF8);
+}
+
+static ErlNifFunc nif_funcs[] = {
+    {"hello", 0, hello_world}
+};
+
+ERL_NIF_INIT(n, nif_funcs, NULL, NULL, NULL, NULL)

--- a/test/lux/nif/run.lux
+++ b/test/lux/nif/run.lux
@@ -1,0 +1,14 @@
+[doc Test that we can build a nif]
+
+[shell test]
+    !env | grep ERL
+    ?SH-PROMPT
+    -[^W][Ee]rror
+    !make
+    ?SH-PROMPT
+    !erl -pa ebin -noinput -run n nonif
+    ?hello from Erlang
+    ?SH-PROMPT
+    !erl -pa ebin -noinput -run n nif
+    ?hello from nif: "Hello world"
+    ?SH-PROMPT

--- a/test/lux/nif/src/n.erl
+++ b/test/lux/nif/src/n.erl
@@ -1,0 +1,25 @@
+-module(n).
+
+-export([nonif/0, nif/0]).
+-export([hello/0]).
+
+-on_load(nif_load/0).
+
+nonif() ->
+    io:format("hello from Erlang\n", []),
+    erlang:halt(0).
+
+nif() ->
+    io:format("hello from nif: ~0p\n", [hello()]),
+    erlang:halt(0).
+
+hello() ->
+    nif_only().
+
+nif_load() ->
+%%    Path = filename:join(code:priv_dir(n), atom_to_list(?MODULE)),
+    Path = filename:join("priv", atom_to_list(?MODULE)),
+    erlang:load_nif(Path, 0).
+
+nif_only() ->
+    erlang:nif_error(not_loaded).


### PR DESCRIPTION
Making it work on most modern *NIX:es, including FreeBSD.

Note: The lux test doesn't yet work :( Building without lux works, but when you run the build from within lux the `erts` directory is added to `ERL_TOP` breaking the include path... But I don't get how that happens? The `readlink` in the makefile?